### PR TITLE
Defer amazonka-eks yaml references to develop-gen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -231,9 +231,6 @@ matrix:
     - env: LIBRARY=amazonka-efs GHCVER=8.2.2 STACK_YAML=stack-8.2.2.yaml CACHE_NAME=amazonka-efs-8.2.2
       compiler: ": #stack 8.2.2"
       addons: {apt: {packages: [ghc-8.2.2], sources: [hvr-ghc]}}
-    - env: LIBRARY=amazonka-eks GHCVER=8.2.2 STACK_YAML=stack-8.2.2.yaml CACHE_NAME=amazonka-eks-8.2.2
-      compiler: ": #stack 8.2.2"
-      addons: {apt: {packages: [ghc-8.2.2], sources: [hvr-ghc]}}
     - env: LIBRARY=amazonka-elasticache GHCVER=8.2.2 STACK_YAML=stack-8.2.2.yaml CACHE_NAME=amazonka-elasticache-8.2.2
       compiler: ": #stack 8.2.2"
       addons: {apt: {packages: [ghc-8.2.2], sources: [hvr-ghc]}}

--- a/stack-7.10.3.yaml
+++ b/stack-7.10.3.yaml
@@ -75,7 +75,6 @@ packages:
   - amazonka-ecr
   - amazonka-ecs
   - amazonka-efs
-  - amazonka-eks
   - amazonka-elasticache
   - amazonka-elasticbeanstalk
   - amazonka-elasticsearch

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -67,7 +67,6 @@ packages:
   - amazonka-ecr
   - amazonka-ecs
   - amazonka-efs
-  - amazonka-eks
   - amazonka-elasticache
   - amazonka-elasticbeanstalk
   - amazonka-elasticsearch

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -68,7 +68,6 @@ packages:
   - amazonka-ecr
   - amazonka-ecs
   - amazonka-efs
-  - amazonka-eks
   - amazonka-elasticache
   - amazonka-elasticbeanstalk
   - amazonka-elasticsearch

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -72,7 +72,6 @@ packages:
   - amazonka-ecr
   - amazonka-ecs
   - amazonka-efs
-  - amazonka-eks
   - amazonka-elasticache
   - amazonka-elasticbeanstalk
   - amazonka-elasticsearch


### PR DESCRIPTION
Follow-up to #24. I ran into trouble regenerating the source because the cabal references were there without the generated source.  To keep the model commits separate from the generated code for upstreaming, I think we want to defer these references to when we rebuild develop-gen.