### PR TITLE
Adapt the generate script to Earnest's process

### DIFF
--- a/README-earnest.md
+++ b/README-earnest.md
@@ -26,3 +26,16 @@ To add support for `${NEW_SERVICE}`, follow these steps:
 
 1. Commit and open a PR to `EarnestResearch/amazonka`'s develop branch.
 
+1. Wait for it to be approved and merged.
+
+1. Regenerate the code on `develop-gen`.
+
+    ```sh
+    scripts/generate
+    ```
+
+1. Check the last commit for sanity, then push the resulting commit to `develop-gen`:
+
+    ```sh
+    git push develop-gen
+    ```

--- a/script/generate
+++ b/script/generate
@@ -2,5 +2,14 @@
 
 set -euo pipefail
 
+git checkout -B develop-gen
+
+git merge -s recursive -X ours develop
+
 ./script/generate-travis
 ./script/generate-stack
+
+pushd gen && make gen && popd
+
+git add -A .
+git commit -am "Regenerate from $(git rev-parse HEAD)"


### PR DESCRIPTION
Automates most of the remaining labor after a merge to `develop`.  It still needs to be kicked off and run locally.  Ideally, this would be a CI process, and not pushing to the same tree as  the source of truth, but that's for another day.