### PR TITLE
remove MacOS specific compilation flags

### DIFF
--- a/amazonka/amazonka.cabal
+++ b/amazonka/amazonka.cabal
@@ -44,7 +44,6 @@ library
         -fwarn-incomplete-uni-patterns
         -fwarn-incomplete-record-updates
         -funbox-strict-fields
-        -optP-Wno-nonportable-include-path
 
     exposed-modules:
           Control.Monad.Trans.AWS

--- a/core/amazonka-core.cabal
+++ b/core/amazonka-core.cabal
@@ -39,7 +39,6 @@ library
         -fwarn-incomplete-uni-patterns
         -fwarn-incomplete-record-updates
         -funbox-strict-fields
-        -optP-Wno-nonportable-include-path
 
     exposed-modules:
           Network.AWS.Compat.Locale

--- a/gen/amazonka-gen.cabal
+++ b/gen/amazonka-gen.cabal
@@ -64,7 +64,6 @@ executable amazonka-gen
         -Wall
         -fwarn-incomplete-uni-patterns
         -fwarn-incomplete-record-updates
-        -optP-Wno-nonportable-include-path
 
     build-depends:
           aeson                >= 1.2


### PR DESCRIPTION
Accidentally included the Macos specific flags in the list of compilation flags for all platforms. They should be guarded by the if os(darwin) condition.

(For future reference, inclusion of the flag helps fix the 

```
ghc: loadArchive: Neither an archive, nor a fat archive: /nix/store/a76n8l1caynyyngdpnyihlrgyr9k9ilg-clang-wrapper-7.1.0/bin/clang++'
ghc: panic! (the 'impossible' happened)
(GHC version 8.6.5 for x86_64-apple-darwin):
loadArchive "/nix/store/a76n8l1caynyyngdpnyihlrgyr9k9ilg-clang-wrapper-7.1.0/bin/clang++": failed
```

issue.

The other fix is in shell.nix

Took the fix from here https://github.com/symphony-org/frost/issues/49